### PR TITLE
[WIP] Reuse tests with IN

### DIFF
--- a/example-prjs/graph/gnn_simple/nnet_graph.h
+++ b/example-prjs/graph/gnn_simple/nnet_graph.h
@@ -46,6 +46,7 @@ namespace nnet {
     
     // Resource reuse info
     static const unsigned io_type = io_parallel;
+    static const unsigned io_stream = false;
     static const unsigned reuse_factor = 1;
     static const unsigned n_zeros = 0;
   };
@@ -66,8 +67,8 @@ namespace nnet {
       #pragma HLS STREAM variable=receivers
       #pragma HLS STREAM variable=senders
     }
-    for(int i = 0; i < CONFIG_T::n_edge; i++) {
-      #pragma HLS PIPELINE II=CONFIG_T::dense_config1::reuse_factor
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor*CONFIG_T::n_edge
+    IN_edge_loop: for(int i = 0; i < CONFIG_T::n_edge; i++) {
       #pragma HLS UNROLL
       index_T r = receivers[i][0];
       index_T s = senders[i][0];
@@ -102,8 +103,8 @@ namespace nnet {
 			typename CONFIG_T::dense_config2::weight_t  core_node_w1[CONFIG_T::n_hidden*CONFIG_T::n_hidden],
 			typename CONFIG_T::dense_config2::bias_t    core_node_b1[CONFIG_T::n_hidden])
   {
-    for(int i = 0; i < CONFIG_T::n_node; i++){
-      #pragma HLS PIPELINE II=CONFIG_T::dense_config1::reuse_factor
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor*CONFIG_T::n_node
+    IN_node_loop: for(int i = 0; i < CONFIG_T::n_node; i++){
       #pragma HLS UNROLL
       data_T p[2*CONFIG_T::n_hidden];
       #pragma HLS ARRAY_PARTITION variable=p complete dim=0
@@ -135,6 +136,7 @@ namespace nnet {
     if(CONFIG_T::io_stream){
       #pragma HLS STREAM variable=X
     }
+    #pragma HLS PIPELINE II=CONFIG_T::reuse_factor*CONFIG_T::dense_config2::n_batch
     data_T R0_logits[CONFIG_T::dense_config1::n_batch][CONFIG_T::dense_config1::n_out];
     #pragma HLS ARRAY_PARTITION variable=R0_logits complete dim=0
     nnet::dense_batch<data_T, data_T, typename CONFIG_T::dense_config1>(X, R0_logits, w0, b0);

--- a/example-prjs/graph/gnn_simple/parameters.h
+++ b/example-prjs/graph/gnn_simple/parameters.h
@@ -18,7 +18,8 @@ typedef ap_fixed<16,6> model_default_t;
 typedef ap_fixed<16,6> input_t;
 typedef ap_fixed<16,6> result_t;
 typedef ap_uint<16> index_t;
-#define REUSE 4
+#define REUSE_GRAPH 1
+#define REUSE_DENSE 1
 #define N_ITERS 1
 #define latent_dim 32
 #define N_FEATURES 3
@@ -30,15 +31,16 @@ typedef ap_uint<16> index_t;
 //hls-fpga-machine-learning insert layer-config
 
 struct graph_config1 : nnet::graph_config {
-  static const bool io_stream = true;
+  static const bool io_stream = false;
   static const bool activate_final = true;
+  static const unsigned reuse_factor = REUSE_GRAPH;
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_batch = N_NODES;
     static const unsigned n_in = N_FEATURES;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -50,14 +52,13 @@ struct graph_config1 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_batch = N_NODES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -69,20 +70,20 @@ struct graph_config1 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
 struct graph_config2 : nnet::graph_config {
-  static const bool io_stream = true;
+  static const bool io_stream = false;
   static const bool activate_final = true;
+  static const unsigned reuse_factor = REUSE_GRAPH;
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = E_FEATURES;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -94,14 +95,13 @@ struct graph_config2 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -113,7 +113,6 @@ struct graph_config2 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
@@ -121,13 +120,15 @@ struct graph_config3 : nnet::graph_config {
   static const unsigned n_edge = N_EDGES;
   static const unsigned n_node = N_NODES;
   static const unsigned n_hidden = latent_dim;
-  static const bool io_stream = true;
+  static const bool io_stream = false;
+  static const unsigned reuse_factor = REUSE_GRAPH;
+
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_in = 3*n_hidden;
     static const unsigned n_out = n_hidden;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -138,13 +139,12 @@ struct graph_config3 : nnet::graph_config {
     static const unsigned n_in = n_hidden;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_in = n_hidden;
     static const unsigned n_out = n_hidden;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -155,7 +155,6 @@ struct graph_config3 : nnet::graph_config {
     static const unsigned n_in = n_hidden;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
@@ -163,12 +162,14 @@ struct graph_config4 : nnet::graph_config {
   static const unsigned n_edge = N_EDGES;
   static const unsigned n_node = N_NODES;
   static const unsigned n_hidden = latent_dim;
+  static const unsigned reuse_factor = REUSE_GRAPH;
+
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_in = 2*n_hidden;
     static const unsigned n_out = n_hidden;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -179,13 +180,12 @@ struct graph_config4 : nnet::graph_config {
     static const unsigned n_in = n_hidden;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_in = n_hidden;
     static const unsigned n_out = n_hidden;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -196,20 +196,21 @@ struct graph_config4 : nnet::graph_config {
     static const unsigned n_in = n_hidden;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
 struct graph_config5 : nnet::graph_config {
   static const bool io_stream = false;
   static const bool activate_final = true;
+  static const unsigned reuse_factor = REUSE_GRAPH;
+
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -221,14 +222,13 @@ struct graph_config5 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -240,20 +240,20 @@ struct graph_config5 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
 struct graph_config6 : nnet::graph_config {
   static const bool io_stream = false;
   static const bool activate_final = false;
+  static const unsigned reuse_factor = REUSE_GRAPH;
 
   struct dense_config1 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = latent_dim;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -265,14 +265,13 @@ struct graph_config6 : nnet::graph_config {
     static const unsigned n_in = latent_dim;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
   struct dense_config2 : nnet::dense_config {
     static const unsigned n_batch = N_EDGES;
     static const unsigned n_in = latent_dim;
     static const unsigned n_out = 1;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
+    static const unsigned reuse_factor = REUSE_DENSE;
     static const unsigned n_zeros = 0;
     static const bool store_weights_in_bram = false;
     typedef accum_default_t accum_t;
@@ -284,7 +283,6 @@ struct graph_config6 : nnet::graph_config {
     static const unsigned n_in = 1;
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::io_parallel;
-    static const unsigned reuse_factor = REUSE;
   };
 };
 
@@ -293,7 +291,7 @@ struct sigmoid_config1 : nnet::activ_config {
   static const unsigned n_in = 1;
   static const unsigned table_size = 1024;
   static const unsigned io_type = nnet::io_parallel;
-  static const unsigned reuse_factor = REUSE;
+  static const unsigned reuse_factor = REUSE_DENSE;
 };
 
 #endif 


### PR DESCRIPTION
- note: work in progress, not necessarily ready to merge yet (need to test with larger graph)
- set reuse factor at IN module level
```
reuse_factor = REUSE_GRAPH * N_NODES (or N_EDGES)
```
- turn off streaming (not sure if it was doing anything?)
- unroll inner node or edge loops
- for 10 nodes, 20 edges, latent dim = 4, see promising results:

```
================================================================
== Performance Estimates
================================================================
+ Timing (ns): 
    * Summary: 
    +--------+-------+----------+------------+
    |  Clock | Target| Estimated| Uncertainty|
    +--------+-------+----------+------------+
    |ap_clk  |   5.00|     5.477|        0.62|
    +--------+-------+----------+------------+
+ Latency (clock cycles): 
    * Summary: 
    +-----+-----+-----+-----+----------+
    |  Latency  |  Interval | Pipeline |
    | min | max | min | max |   Type   |
    +-----+-----+-----+-----+----------+
    |  194|  194|   20|   20| dataflow |
    +-----+-----+-----+-----+----------+
    + Detail: 
        * Instance: 
        +-------------------------+----------------------+-----+-----+-----+-----+----------+
        |                         |                      |  Latency  |  Interval | Pipeline |
        |         Instance        |        Module        | min | max | min | max |   Type   |
        +-------------------------+----------------------+-----+-----+-----+-----+----------+
        |graph_independent_1_U0   |graph_independent_1   |   50|   50|   20|   20| function |
        |graph_independent_2_U0   |graph_independent_2   |   50|   50|   20|   20| function |
        |IN_edge_module_U0        |IN_edge_module        |   38|   38|   20|   20| function |
        |graph_independent_U0     |graph_independent     |   48|   48|   20|   20| function |
        |graph_independent_3_U0   |graph_independent_3   |   29|   29|   10|   10| function |
        |sigmoid_batch_U0         |sigmoid_batch         |    2|    2|    1|    1| function |
        |myproject_entry3_U0      |myproject_entry3      |    0|    0|    0|    0|   none   |
        |myproject_entry862_U0    |myproject_entry862    |    0|    0|    0|    0|   none   |
        |Block_arrayctor_loop_U0  |Block_arrayctor_loop  |    0|    0|    0|    0|   none   |
        +-------------------------+----------------------+-----+-----+-----+-----+----------+
        * Loop: 
        N/A
================================================================
== Utilization Estimates
================================================================
* Summary: 
+---------------------+---------+-------+---------+--------+-----+
|         Name        | BRAM_18K| DSP48E|    FF   |   LUT  | URAM|
+---------------------+---------+-------+---------+--------+-----+
|DSP                  |        -|      -|        -|       -|    -|
|Expression           |        -|      -|        0|     930|    -|
|FIFO                 |      270|      -|     6380|   13162|    -|
|Instance             |       20|    150|    43411|   30658|    -|
|Memory               |        -|      -|        -|       -|    -|
|Multiplexer          |        -|      -|        -|    2016|    -|
|Register             |        -|      -|      226|       -|    -|
+---------------------+---------+-------+---------+--------+-----+
|Total                |      290|    150|    50017|   46766|    0|
+---------------------+---------+-------+---------+--------+-----+
|Available SLR        |     2160|   2760|   663360|  331680|    0|
+---------------------+---------+-------+---------+--------+-----+
|Utilization SLR (%)  |       13|      5|        7|      14|  100|
+---------------------+---------+-------+---------+--------+-----+
|Available            |     4320|   5520|  1326720|  663360|    0|
+---------------------+---------+-------+---------+--------+-----+
|Utilization (%)      |        6|      2|        3|       7|    0|
+---------------------+---------+-------+---------+--------+-----+

+ Detail: 
    * Instance: 
    +-------------------------+----------------------+---------+-------+-------+------+-----+
    |         Instance        |        Module        | BRAM_18K| DSP48E|   FF  |  LUT | URAM|
    +-------------------------+----------------------+---------+-------+-------+------+-----+
    |Block_arrayctor_loop_U0  |Block_arrayctor_loop  |        0|      0|      2|    11|    0|
    |IN_edge_module_U0        |IN_edge_module        |        0|     51|   9086|  6630|    0|
    |graph_independent_U0     |graph_independent     |        0|     19|   6244|  3596|    0|
    |graph_independent_1_U0   |graph_independent_1   |        0|     29|  11441|  6987|    0|
    |graph_independent_2_U0   |graph_independent_2   |        0|     29|  12079|  6679|    0|
    |graph_independent_3_U0   |graph_independent_3   |        0|     22|   4089|  3507|    0|
    |myproject_entry3_U0      |myproject_entry3      |        0|      0|      3|    92|    0|
    |myproject_entry862_U0    |myproject_entry862    |        0|      0|      3|    92|    0|
    |sigmoid_batch_U0         |sigmoid_batch         |       20|      0|    464|  3064|    0|
    +-------------------------+----------------------+---------+-------+-------+------+-----+
    |Total                    |                      |       20|    150|  43411| 30658|    0|
    +-------------------------+----------------------+---------+-------+-------+------+-----+
```
